### PR TITLE
Torna limite_de_uso() e trial() opcionais

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Projeto para construir um Wrapper Python para a API do [Pagseguro versão 3](htt
 Projeto escrito com Python 3. A linguagem utilizada também para codificar será o português por duas razões:
 
 1. O Pagseguro em si é um Gateway brasileiro com sua documentação em português
-1. Essa lib está sendo desenvolvida no como projeto prático da turma Luciano Ramlho do curso [Python Pro](https://www.python.pro.br)
+1. Essa lib está sendo desenvolvida como projeto prático da turma Luciano Ramalho do curso [Python Pro](https://www.python.pro.br)
 
 # Contribuidores
 
 Renzo Nuccitelli (@renzon)
+Tânio Scherer (@taniodev)
 
 # Instalação
 
@@ -30,7 +31,7 @@ pipenv install pygseguro
 
 # Como usar
 
-## Configuraçao Padrão
+## Configuração Padrão
 
 Utilize essa configuração se as chamadas costumam usar sempre a mesma configuração
 ```python
@@ -78,12 +79,12 @@ ConfigApp(app_id='1234', app_key='****')
 ...     'Plano Turma de Curso de Python',
 ...     'Plano de pagamento da turma Luciano Ramalho',
 ...     'renzo@python.pro.br')
->>> freq_mensal = plano_identificacao.frequencia_mensal()
->>> expiracao = freq_mensal.expiracao_em_meses(meses=10)
->>> trial = expiracao.trial(dias=2)
+>>> expiracao = plano_identificacao.expiracao_em_meses(meses=10)
+>>> valores_automaticos = expiracao.valores_automaticos(Decimal('180.00'), Decimal('30.39'))
+>>> freq_mensal = valores_automaticos.frequencia_mensal()
+>>> trial = freq_mensal.trial(dias=2)
 >>> limite_de_uso = trial.limite_de_uso(100)
->>> valores_automaticos = limite_de_uso.valores_automaticos(Decimal('180.00'), Decimal('30.39'))
->>> urls_gancho = valores_automaticos.urls_gancho(
+>>> urls_gancho = limite_de_uso.urls_gancho(
 ...     'https://seusite.com.br/obrigado', 'https://seusite.com.br/revisar', 'https://seusite.com.br/cancelar'
 ... )
 >>> plano_recorrente=urls_gancho.criar_no_pagseguro()
@@ -103,9 +104,9 @@ True
 ...     'Plano Turma de Curso de Python',
 ...     'Plano de pagamento da turma Luciano Ramalho',
 ...     'renzo@python.pro.br'
-... ).frequencia_mensal().expiracao_em_meses(meses=10).trial(dias=2).limite_de_uso(100).valores_automaticos(
+... ).expiracao_em_meses(meses=10).valores_automaticos(
 ...     Decimal('180.00'), Decimal('30.39')
-... ).urls_gancho(
+... ).frequencia_mensal().trial(dias=2).limite_de_uso(100).urls_gancho(
 ...     'https://seusite.com.br/obrigado', 'https://seusite.com.br/revisar', 'https://seusite.com.br/cancelar'
 ... ).criar_no_pagseguro()
 >>> isinstance(plano_recorrente.codigo, str)

--- a/pygseguro/plano_recorrente_automatico.py
+++ b/pygseguro/plano_recorrente_automatico.py
@@ -57,18 +57,6 @@ class PlanoAutomaticoIdentificacao(PassoDePlanoRecorrente):
             self._receiver['email'] = receiver_email
             self._main_data['receiver'] = self._receiver
 
-    def frequencia_mensal(self):
-        frequencia = self._construir_proximo_passo(FrequenciaPlanoAutomatico)
-        frequencia._manipular_payload(FrequenciaPlanoAutomatico.MONTHLY)
-        return frequencia
-
-
-class FrequenciaPlanoAutomatico(PassoDePlanoRecorrente):
-    MONTHLY = 'MONTHLY'
-
-    def _manipular_payload(self, frequencia: str):
-        self._pre_approval['period'] = frequencia
-
     def expiracao_em_meses(self, meses: int) -> 'Expiracao':
         expiracao = self._construir_proximo_passo(Expiracao)
         expiracao._manipular_payload(Expiracao.MONTHS, meses)
@@ -83,36 +71,22 @@ class Expiracao(PassoDePlanoRecorrente):
         self._expiration['value'] = valor
         self._pre_approval['expiration'] = self._expiration
 
-    def trial(self, dias: int) -> 'Trial':
-        trial = self._construir_proximo_passo(Trial)
-        trial._manipular_payload(dias)
-        return trial
-
-
-class Trial(PassoDePlanoRecorrente):
-
-    def _manipular_payload(self, dias: int):
-        self._pre_approval['trialPeriodDuration'] = dias
-
-    def limite_de_uso(self, quantidade: int) -> 'LimiteDeUso':
-        """
-        Define a quantidade de adesões máximas para o plano automático
-        :param quantidade:
-        :return: LimiteDeUso
-        """
-        limite = self._construir_proximo_passo(LimiteDeUso)
-        limite._manipular_payload(quantidade)
-        return limite
-
-
-class LimiteDeUso(PassoDePlanoRecorrente):
-    def _manipular_payload(self, quantidade: int):
-        self._main_data['maxUses'] = quantidade
-
     def valores_automaticos(self, valor_periodico: Decimal, taxa_adesao: Decimal = None) -> 'ValoresAutomaticos':
         valores = self._construir_proximo_passo(ValoresAutomaticos)
         valores._manipular_payload(valor_periodico, taxa_adesao)
         return valores
+
+
+class ValoresAutomaticos(PassoDePlanoRecorrente):
+    def _manipular_payload(self, valor_periodico: Decimal, taxa_adesao: Decimal = None):
+        self._pre_approval['amountPerPayment'] = _to_decimal_string(valor_periodico)
+        if taxa_adesao is not None:
+            self._pre_approval['membershipFee'] = _to_decimal_string(taxa_adesao)
+
+    def frequencia_mensal(self):
+        frequencia = self._construir_proximo_passo(FrequenciaPlanoAutomatico)
+        frequencia._manipular_payload(FrequenciaPlanoAutomatico.MONTHLY)
+        return frequencia
 
 
 class UltimoPasso(PassoDePlanoRecorrente):
@@ -131,18 +105,45 @@ class UltimoPasso(PassoDePlanoRecorrente):
         dt = datetime.fromisoformat(codigo_data['date']).astimezone(pytz.UTC)
         return PlanoAutomaticoRecorrente(codigo_data['code'], dt)
 
+    def limite_de_uso(self, quantidade: int) -> 'LimiteDeUso':
+        """
+        Defina a quantidade máxima de consumidores que podem aderir ao plano automático (Opcional)
+        :param quantidade: limite de adesões
+        :return: LimiteDeUso
+        """
+        limite = self._construir_proximo_passo(LimiteDeUso)
+        limite._manipular_payload(quantidade)
+        return limite
 
-class ValoresAutomaticos(UltimoPasso):
-    def _manipular_payload(self, valor_periodico: Decimal, taxa_adesao: Decimal = None):
-        self._pre_approval['amountPerPayment'] = _to_decimal_string(valor_periodico)
-        if taxa_adesao is not None:
-            self._pre_approval['membershipFee'] = _to_decimal_string(taxa_adesao)
+    def trial(self, dias: int) -> 'Trial':
+        """Defina um período de testes, em dias (Opcional)"""
+        trial = self._construir_proximo_passo(Trial)
+        trial._manipular_payload(dias)
+        return trial
 
     def urls_gancho(self, redirecionamento_url: str = None, revisao_url: str = None,
                     cancelamento_url: str = None) -> 'UrlsGancho':
+        """Defina URLs de redirecionamento (Opcional)"""
         urls = self._construir_proximo_passo(UrlsGancho)
         urls._manipular_payload(redirecionamento_url, revisao_url, cancelamento_url)
         return urls
+
+
+class FrequenciaPlanoAutomatico(UltimoPasso):
+    MONTHLY = 'MONTHLY'
+
+    def _manipular_payload(self, frequencia: str):
+        self._pre_approval['period'] = frequencia
+
+
+class LimiteDeUso(UltimoPasso):
+    def _manipular_payload(self, quantidade: int):
+        self._main_data['maxUses'] = quantidade
+
+
+class Trial(UltimoPasso):
+    def _manipular_payload(self, dias: int):
+        self._pre_approval['trialPeriodDuration'] = dias
 
 
 class UrlsGancho(UltimoPasso):


### PR DESCRIPTION
* Foi feita uma alteração na ordem das classes e métodos presentes
no módulo 'pygseguro/plano_recorrente_automatico.py', de modo a
possibilitar que os métodos obrigatórios para a criação de um plano
sejam chamados primeiro, e os métodos opcionais por último.
* Alguns testes foram atualizados para aceitar essa mudança.
* Os métodos 'limite_de_uso()', 'trial()' e 'urls_gancho()' foram
movidos para a classe 'UltimoPasso' com a finalidade de torná-los
opcionais e independentes de ordem de chamada.
* Atualiza as informações no README.md.

This closes #34 and closes #35